### PR TITLE
logback adapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.alibaba.nacos</groupId>
+    <artifactId>logback-adpater</artifactId>
+    <version>1.0.0</version>
+    <name>logback-adpater</name>
+    <description>logback-adpater</description>
+    <properties>
+        <java.version>17</java.version>
+        <slf4j-api.version>2.0.6</slf4j-api.version>
+        <logback.version>1.4.5</logback.version>
+    </properties>
+    <dependencies>
+
+        <dependency>
+            <groupId>com.alibaba.nacos</groupId>
+            <artifactId>nacos-common</artifactId>
+            <version>2.2.1-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Logging libs -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-api.version}</version>
+        </dependency>
+    
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+    
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/alibaba/nacos/logbackadpater/NacosClientPropertyModel.java
+++ b/src/main/java/com/alibaba/nacos/logbackadpater/NacosClientPropertyModel.java
@@ -1,0 +1,58 @@
+/*
+ *
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.alibaba.nacos.logbackadpater;
+
+import ch.qos.logback.core.model.NamedModel;
+
+/**
+ * Logback model to support <nacosClientProperty/> tags.
+ *
+ * @author hujun
+ */
+public class NacosClientPropertyModel extends NamedModel {
+    private String scope;
+    
+    private String defaultValue;
+    
+    private String source;
+    
+    String getScope() {
+        return this.scope;
+    }
+    
+    void setScope(String scope) {
+        this.scope = scope;
+    }
+    
+    String getDefaultValue() {
+        return this.defaultValue;
+    }
+    
+    void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+    
+    String getSource() {
+        return this.source;
+    }
+    
+    void setSource(String source) {
+        this.source = source;
+    }
+}

--- a/src/main/java/com/alibaba/nacos/logbackadpater/NacosClientPropertyModelAction.java
+++ b/src/main/java/com/alibaba/nacos/logbackadpater/NacosClientPropertyModelAction.java
@@ -1,0 +1,46 @@
+/*
+ *
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.alibaba.nacos.logbackadpater;
+
+import ch.qos.logback.core.joran.action.BaseModelAction;
+import ch.qos.logback.core.joran.spi.SaxEventInterpretationContext;
+import ch.qos.logback.core.model.Model;
+import org.xml.sax.Attributes;
+
+/**
+ * Logback model action to support <nacosClientProperty/> tags.
+ *
+ * @author hujun
+ */
+public class NacosClientPropertyModelAction extends BaseModelAction {
+    private static final String SOURCE_ATTRIBUTE = "source";
+    
+    private static final String DEFAULT_VALUE_ATTRIBUTE = "defaultValue";
+    
+    @Override
+    protected Model buildCurrentModel(SaxEventInterpretationContext interpretationContext, String name,
+            Attributes attributes) {
+        NacosClientPropertyModel model = new NacosClientPropertyModel();
+        model.setName(attributes.getValue(NAME_ATTRIBUTE));
+        model.setSource(attributes.getValue(SOURCE_ATTRIBUTE));
+        model.setScope(attributes.getValue(SCOPE_ATTRIBUTE));
+        model.setDefaultValue(attributes.getValue(DEFAULT_VALUE_ATTRIBUTE));
+        return model;
+    }
+}

--- a/src/main/java/com/alibaba/nacos/logbackadpater/NacosClientPropertyModelHandler.java
+++ b/src/main/java/com/alibaba/nacos/logbackadpater/NacosClientPropertyModelHandler.java
@@ -1,0 +1,64 @@
+/*
+ *
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.alibaba.nacos.logbackadpater;
+
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.joran.action.ActionUtil;
+import ch.qos.logback.core.model.Model;
+import ch.qos.logback.core.model.ModelUtil;
+import ch.qos.logback.core.model.processor.ModelHandlerBase;
+import ch.qos.logback.core.model.processor.ModelHandlerException;
+import ch.qos.logback.core.model.processor.ModelInterpretationContext;
+import ch.qos.logback.core.util.OptionHelper;
+import com.alibaba.nacos.common.log.NacosLogbackProperties;
+import com.alibaba.nacos.common.spi.NacosServiceLoader;
+
+import java.util.Collection;
+
+/**
+ * Logback model to support <nacosClientProperty/> tags.
+ * for example:
+ * <nacosClientProperty scope="context" name="logPath" source="system.log.path" defaultValue="/root" />
+ *
+ * @author hujun
+ */
+public class NacosClientPropertyModelHandler extends ModelHandlerBase {
+    
+    public NacosClientPropertyModelHandler(Context context) {
+        super(context);
+    }
+    
+    @Override
+    public void handle(ModelInterpretationContext intercon, Model model) throws ModelHandlerException {
+        NacosClientPropertyModel propertyModel = (NacosClientPropertyModel) model;
+        ActionUtil.Scope scope = ActionUtil.stringToScope(propertyModel.getScope());
+        String defaultValue = propertyModel.getDefaultValue();
+        String source = propertyModel.getSource();
+        if (OptionHelper.isNullOrEmpty(propertyModel.getName()) || OptionHelper.isNullOrEmpty(source)) {
+            addError("The \"name\" and \"source\" attributes of <nacosClientProperty> must be set");
+        }
+        ModelUtil.setProperty(intercon, propertyModel.getName(), getValue(source, defaultValue), scope);
+    }
+    
+    private String getValue(String source, String defaultValue) {
+        Collection<NacosLogbackProperties> logbackClientProperties = NacosServiceLoader.load(
+                NacosLogbackProperties.class);
+        return logbackClientProperties.stream().findFirst().get().getValue(source, defaultValue);
+    }
+}

--- a/src/main/java/com/alibaba/nacos/logbackadpater/NacosLogbackConfiguratorAdapterV2.java
+++ b/src/main/java/com/alibaba/nacos/logbackadpater/NacosLogbackConfiguratorAdapterV2.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 1999-2018 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.nacos.logbackadpater;
+
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.joran.spi.ElementSelector;
+import ch.qos.logback.core.joran.spi.JoranException;
+import ch.qos.logback.core.joran.spi.RuleStore;
+import ch.qos.logback.core.model.Model;
+import ch.qos.logback.core.model.processor.DefaultProcessor;
+import com.alibaba.nacos.common.log.NacosLogbackConfigurator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * ensure that Nacos configuration does not affect user configuration savepoints and  scanning url.
+ *
+ * @author hujun
+ */
+public class NacosLogbackConfiguratorAdapterV2 extends JoranConfigurator implements NacosLogbackConfigurator {
+    
+    /**
+     * ensure that Nacos configuration does not affect user configuration savepoints.
+     *
+     * @param top safe data
+     */
+    @Override
+    public void registerSafeConfiguration(Model top) {
+    }
+    
+    protected void addModelHandlerAssociations(DefaultProcessor defaultProcessor) {
+        defaultProcessor.addHandler(NacosClientPropertyModel.class,
+                (handlerContext, handlerMic) -> new NacosClientPropertyModelHandler(this.context));
+        super.addModelHandlerAssociations(defaultProcessor);
+    }
+    
+    public void addElementSelectorAndActionAssociations(RuleStore ruleStore) {
+        super.addElementSelectorAndActionAssociations(ruleStore);
+        ruleStore.addRule(new ElementSelector("configuration/nacosClientProperty"),
+                NacosClientPropertyModelAction::new);
+    }
+    
+    @Override
+    public int getVersion() {
+        return 2;
+    }
+    
+    @Override
+    public void setContext(Object loggerContext) {
+        super.setContext((Context) loggerContext);
+    }
+    
+    @Override
+    public void configure(URL url) throws Exception {
+        InputStream in = null;
+        try {
+            URLConnection urlConnection = url.openConnection();
+            urlConnection.setUseCaches(false);
+            in = urlConnection.getInputStream();
+            doConfigure(in, url.toExternalForm());
+        } catch (IOException ioe) {
+            String errMsg = "Could not open URL [" + url + "].";
+            addError(errMsg, ioe);
+            throw new JoranException(errMsg, ioe);
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException ioe) {
+                    String errMsg = "Could not close input stream";
+                    addError(errMsg, ioe);
+                    throw new JoranException(errMsg, ioe);
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/com.alibaba.nacos.common.log.NacosLogbackConfigurator
+++ b/src/main/resources/META-INF/services/com.alibaba.nacos.common.log.NacosLogbackConfigurator
@@ -1,0 +1,18 @@
+#
+#  Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+com.alibaba.nacos.logbackadpater.NacosLogbackConfiguratorAdapterV2


### PR DESCRIPTION
issue:#9860
修改方案：
1.通过判断高版本的类是否存在选择不同版本的api
2.通过spi的方式+新增logback-adapter的依赖解决不同版本api存在同一个项目中编译报错的问题
测试场景：
1.2.9 版本的logback的demo服务使用该依赖启动可正常加载logback配置
1.4.5 版本的logback的demo服务使用该依赖启动可正常加载logback配置
